### PR TITLE
Support ExecProcess in shim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
         go-version: [1.17.x]
 
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+
       - uses: actions/checkout@v2
         with:
           path: src/github.com/fuweid/embedshim
@@ -54,9 +58,9 @@ jobs:
           echo "::endgroup::"
 
       - name: golangci-lint check
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42.0
+          version: v1.44.2
           args: --timeout=5m
           working-directory: src/github.com/fuweid/embedshim
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.16.8]
+        go-version: [1.17.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DESTDIR ?= /usr/local
 
 # command name
-COMMANDS=embedshim-containerd
+COMMANDS=embedshim-containerd embedshim-runcext
 
 # binaries
 BINARIES=$(addprefix bin/,$(COMMANDS))

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ io.containerd.runtime.v1        embed                    linux/amd64    ok
 The embedshim supports to run container in headless or with input.
 But it still works in progress, do not use in production.
 
-* [ ] Support Exec
 * [ ] Support Pause/Resume
 * [ ] Metrics Support
 * [ ] Task Event(Create/Start/Exit/Delete/OOM) support

--- a/bundle_utils.go
+++ b/bundle_utils.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 
 	pkgbundle "github.com/fuweid/embedshim/pkg/bundle"
+	"github.com/fuweid/embedshim/pkg/runcext"
 
 	"github.com/containerd/containerd/runtime"
 	"github.com/containerd/containerd/runtime/v2/runc/options"
-	"github.com/containerd/go-runc"
 	"github.com/gogo/protobuf/types"
 )
 
@@ -39,22 +39,8 @@ var (
 	bundleInitPidFile = "init.pid"
 )
 
-func newPidFile(bundle *pkgbundle.Bundle) *pidFile {
-	return &pidFile{
-		path: filepath.Join(bundle.Path, bundleInitPidFile),
-	}
-}
-
-type pidFile struct {
-	path string
-}
-
-func (p *pidFile) Path() string {
-	return p.path
-}
-
-func (p *pidFile) Read() (int, error) {
-	return runc.ReadPidFile(p.path)
+func newInitPidFile(bundle *pkgbundle.Bundle) *runcext.PidFile {
+	return runcext.NewPidFile(filepath.Join(bundle.Path, bundleInitPidFile))
 }
 
 func readInitTraceEventID(b *pkgbundle.Bundle) (uint64, error) {

--- a/cmd/embedshim-runcext/app.go
+++ b/cmd/embedshim-runcext/app.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"os"
+
+	"github.com/containerd/containerd/pkg/userns"
+	"github.com/containerd/containerd/sys/reaper"
+	"github.com/urfave/cli"
+)
+
+// newApp is based on https://github.com/opencontainers/runc/blob/899342b5d49434611635d64f64c343e2a1aeee0a/main.go.
+//
+// NOTE: newApp only extends functionality about runc-exec command.
+func newApp() *cli.App {
+	app := cli.NewApp()
+	app.Name = "runcext"
+	app.EnableBashCompletion = true
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "command",
+			Usage: "set the command as runtime",
+			Value: "runc",
+		},
+		cli.BoolFlag{
+			Name:  "debug",
+			Usage: "enable debug logging",
+		},
+		cli.StringFlag{
+			Name:  "log",
+			Value: "",
+			Usage: "set the log file to write runc logs to (default is '/dev/stderr')",
+		},
+		cli.StringFlag{
+			Name:  "log-format",
+			Value: "text",
+			Usage: "set the log format ('text' (default), or 'json')",
+		},
+		cli.StringFlag{
+			Name:  "root",
+			Value: defaultRuncRoot(),
+			Usage: "root directory for storage of container state (this should be located in tmpfs)",
+		},
+		cli.BoolFlag{
+			Name:  "systemd-cgroup",
+			Usage: "enable systemd cgroup support, expects cgroupsPath to be of form \"slice:prefix:name\" for e.g. \"system.slice:runc:434234\"",
+		},
+		cli.StringFlag{
+			Name:  "rootless",
+			Value: "auto",
+			Usage: "ignore cgroup permission errors ('true', 'false', or 'auto')",
+		},
+	}
+	app.Commands = append(app.Commands, execCommand)
+	app.Before = func(_ *cli.Context) error {
+		if err := reaper.SetSubreaper(1); err != nil {
+			return err
+		}
+		return nil
+	}
+	return app
+}
+
+func defaultRuncRoot() string {
+	root := "/run/runc"
+	if shouldHonorXDGRuntimeDir() {
+		if runtimeDir := os.Getenv("XDG_RUNTIME_DIR"); runtimeDir != "" {
+			root = runtimeDir + "/runc"
+		}
+	}
+	return root
+}
+
+// shouldHonorXDGRuntimeDir is copied from https://github.com/opencontainers/runc/blob/899342b5d49434611635d64f64c343e2a1aeee0a/rootless_linux.go#L54.
+func shouldHonorXDGRuntimeDir() bool {
+	if os.Geteuid() != 0 {
+		return true
+	}
+	if !userns.RunningInUserNS() {
+		// euid == 0 , in the initial ns (i.e. the real root)
+		// in this case, we should use /run/runc and ignore
+		// $XDG_RUNTIME_DIR (e.g. /run/user/0) for backward
+		// compatibility.
+		return false
+	}
+	// euid = 0, in a userns.
+	u, ok := os.LookupEnv("USER")
+	return !ok || u != "root"
+}

--- a/cmd/embedshim-runcext/exec.go
+++ b/cmd/embedshim-runcext/exec.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"github.com/fuweid/embedshim/pkg/pidfd"
+	"github.com/fuweid/embedshim/pkg/runcext"
+	"github.com/urfave/cli"
+	"golang.org/x/sys/unix"
+)
+
+// execCommand is based on https://github.com/opencontainers/runc/blob/899342b5d49434611635d64f64c343e2a1aeee0a/exec.go.
+var execCommand = cli.Command{
+	Name:  "exec",
+	Usage: "execute new process inside the container",
+	ArgsUsage: `<container-id> <command> [command options]  || -p process.json <container-id>
+
+Where "<container-id>" is the name for the instance of the container and
+"<command>" is the command to be executed in the container.
+"<command>" can't be empty unless a "-p" flag provided.
+
+EXAMPLE:
+For example, if the container is configured to run the linux ps command the
+following will output a list of processes running in the container:
+
+       # runc exec <container-id> ps`,
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "console-socket",
+			Usage: "path to an AF_UNIX socket which will receive a file descriptor referencing the master end of the console's pseudoterminal",
+		},
+		cli.StringFlag{
+			Name:  "cwd",
+			Usage: "current working directory in the container",
+		},
+		cli.StringSliceFlag{
+			Name:  "env, e",
+			Usage: "set environment variables",
+		},
+		cli.BoolFlag{
+			Name:  "tty, t",
+			Usage: "allocate a pseudo-TTY",
+		},
+		cli.StringFlag{
+			Name:  "user, u",
+			Usage: "UID (format: <uid>[:<gid>])",
+		},
+		cli.Int64SliceFlag{
+			Name:  "additional-gids, g",
+			Usage: "additional gids",
+		},
+		cli.StringFlag{
+			Name:  "process, p",
+			Usage: "path to the process.json",
+		},
+		cli.BoolFlag{
+			Name:  "detach,d",
+			Usage: "detach from the container's process",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "specify the file to write the process id to",
+		},
+		cli.StringFlag{
+			Name:  "process-label",
+			Usage: "set the asm process label for the process commonly used with selinux",
+		},
+		cli.StringFlag{
+			Name:  "apparmor",
+			Usage: "set the apparmor profile for the process",
+		},
+		cli.BoolFlag{
+			Name:  "no-new-privs",
+			Usage: "set the no new privileges value for the process",
+		},
+		cli.StringSliceFlag{
+			Name:  "cap, c",
+			Value: &cli.StringSlice{},
+			Usage: "add a capability to the bounding set for the process",
+		},
+		cli.IntFlag{
+			Name:  "preserve-fds",
+			Usage: "Pass N additional file descriptors to the container (stdio + $LISTEN_FDS + N in total)",
+		},
+		cli.StringSliceFlag{
+			Name:  "cgroup",
+			Usage: "run the process in an (existing) sub-cgroup(s). Format is [<controller>:]<cgroup>.",
+		},
+		cli.BoolFlag{
+			Name:  "ignore-paused",
+			Usage: "allow exec in a paused container",
+		},
+	},
+	Action: func(clicontext *cli.Context) error {
+		return runExec(clicontext)
+	},
+	SkipArgReorder: true,
+}
+
+func runExec(clicontext *cli.Context) (retErr error) {
+	ctx := context.Background()
+	cid := clicontext.Args().First()
+
+	execPidfile, err := getExecPidFilePath(clicontext)
+	if err != nil {
+		return err
+	}
+
+	syncPipe, err := getProcSyncPipe()
+	if err != nil {
+		return err
+	}
+
+	deferCloseSyncPipe := true
+	defer func() {
+		if retErr != nil && deferCloseSyncPipe {
+			syncPipe.Close()
+			deferCloseSyncPipe = false
+		}
+	}()
+
+	runErr := func() (retErr error) {
+		r := newRuntime(clicontext)
+
+		execArgs, err := getExecArgs(clicontext, cid)
+		if err != nil {
+			return fmt.Errorf("failed to get exec arguments: %w", err)
+		}
+
+		execCmd := runcext.RuntimeCommand(ctx, r, execArgs...)
+
+		// NOTE: Just by-pass the standard IO
+		execCmd.Stdin = os.Stdin
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+
+		if err := execCmd.Run(); err != nil {
+			return fmt.Errorf("failed to run: %w", err)
+		}
+
+		execPid, err := execPidfile.Read()
+		if err != nil {
+			return fmt.Errorf("failed to read exec pid from file: %w", err)
+		}
+		defer func() {
+			if retErr != nil {
+				unix.Kill(execPid, unix.SIGKILL)
+			}
+		}()
+
+		pidFD, err := pidfd.Open(uint32(execPid), 0)
+		if err != nil {
+			return fmt.Errorf("failed to open pidfd on exec process: %w", err)
+		}
+
+		if err := syncParentExecPid(syncPipe, uint32(execPid)); err != nil {
+			return err
+		}
+
+		if err := syncParentExecStatus(syncPipe, pidFD, execPid); err != nil {
+			return err
+		}
+
+		syncPipe.Close()
+		deferCloseSyncPipe = false
+		return nil
+	}()
+	if runErr != nil {
+		return runcext.WriteProcSyncMessage(syncPipe, runcext.NewProcSyncErrorMessage(runErr))
+	}
+	return nil
+}
+
+func syncParentExecPid(syncPipe *os.File, execPid uint32) error {
+	msg := runcext.NewProcSyncExecPidMessage(execPid)
+
+	if err := runcext.WriteProcSyncMessage(syncPipe, msg); err != nil {
+		return fmt.Errorf("failed to sync %v: %w", msg, err)
+	}
+
+	return runcext.ReadProcSync(syncPipe, runcext.ProcSyncExecPidDone)
+}
+
+func syncParentExecStatus(syncPipe *os.File, fd pidfd.FD, execPid int) error {
+	info := &pidfd.Siginfo{}
+
+	err := fd.Waitid(info, unix.WNOHANG|unix.WNOWAIT|unix.WEXITED, nil)
+	if err != nil {
+		return fmt.Errorf("failed to check exec process status: %w", err)
+	}
+
+	exited := false
+	exitedStatus := uint32(0)
+
+	if info.Pid != 0 {
+		var status unix.WaitStatus
+
+		for {
+			_, err = unix.Wait4(execPid, &status, 0, nil)
+			if err != syscall.EINTR {
+				break
+			}
+		}
+		if err != nil {
+			return fmt.Errorf("failed to reap the exit process status: %w", err)
+		}
+
+		exited = true
+		exitedStatus = uint32(status)
+	}
+
+	msg := runcext.NewProcSyncExecStatusMessage(exited, exitedStatus)
+	if err := runcext.WriteProcSyncMessage(syncPipe, msg); err != nil {
+		return fmt.Errorf("failed to sync %v: %w", msg, err)
+	}
+
+	return runcext.ReadProcSync(syncPipe, runcext.ProcSyncExecStatusDone)
+}
+
+func getProcSyncPipe() (*os.File, error) {
+	key := runcext.EnvNameProcSyncPipe
+
+	pipeFD, err := strconv.Atoi(os.Getenv(key))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get env %v: %w", key, err)
+	}
+	return os.NewFile(uintptr(pipeFD), key), nil
+}
+
+func getExecPidFilePath(clicontext *cli.Context) (*runcext.PidFile, error) {
+	pidFilePath := clicontext.String("pid-file")
+	if pidFilePath == "" {
+		return nil, fmt.Errorf("pid-file is required")
+	}
+
+	abs, err := filepath.Abs(pidFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get absolute path for --pid-file: %w", err)
+	}
+	return runcext.NewPidFile(abs), nil
+}

--- a/cmd/embedshim-runcext/exec.go
+++ b/cmd/embedshim-runcext/exec.go
@@ -133,7 +133,7 @@ func runExec(clicontext *cli.Context) (retErr error) {
 			return fmt.Errorf("failed to get exec arguments: %w", err)
 		}
 
-		execCmd := runcext.RuntimeCommand(ctx, r, execArgs...)
+		execCmd := runcext.RuntimeCommand(ctx, false, r, execArgs...)
 
 		// NOTE: Just by-pass the standard IO
 		execCmd.Stdin = os.Stdin

--- a/cmd/embedshim-runcext/main.go
+++ b/cmd/embedshim-runcext/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	app := newApp()
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "runcext: %s\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/embedshim-runcext/utils.go
+++ b/cmd/embedshim-runcext/utils.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/containerd/go-runc"
+	"github.com/urfave/cli"
+	"golang.org/x/sys/unix"
+)
+
+func newRuntime(clicontext *cli.Context) *runc.Runc {
+	return &runc.Runc{
+		Command:       clicontext.GlobalString("command"),
+		Log:           clicontext.GlobalString("log"),
+		LogFormat:     runc.Format(clicontext.GlobalString("log-format")),
+		PdeathSignal:  unix.SIGKILL,
+		Root:          clicontext.GlobalString("root"),
+		SystemdCgroup: clicontext.GlobalBool("systemd-cgroup"),
+	}
+}
+
+func getExecArgs(clicontext *cli.Context, cid string) (out []string, err error) {
+	out = append(out, "exec")
+	if skt := clicontext.String("console-socket"); skt != "" {
+		out = append(out, "--console-socket", skt)
+	}
+	if detach := clicontext.Bool("detach"); detach {
+		out = append(out, "--detach")
+	}
+	if processJSON := clicontext.String("process"); processJSON != "" {
+		abs, err := filepath.Abs(processJSON)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, "--process", abs)
+	}
+	if pidFilePath := clicontext.String("pid-file"); pidFilePath != "" {
+		abs, err := filepath.Abs(pidFilePath)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, "--pid-file", abs)
+	}
+	out = append(out, cid)
+	return out, nil
+}

--- a/delete_state.go
+++ b/delete_state.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/console"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/runtime"
 	google_protobuf "github.com/gogo/protobuf/types"
 )
 
@@ -64,7 +65,7 @@ func (s *deletedState) SetExited(status int) {
 	// no op
 }
 
-func (s *deletedState) Exec(ctx context.Context, path string, r *ExecConfig) (Process, error) {
+func (s *deletedState) Exec(ctx context.Context, id string, opts runtime.ExecOpts) (runtime.Process, error) {
 	return nil, fmt.Errorf("cannot exec in a deleted state")
 }
 

--- a/exec_process.go
+++ b/exec_process.go
@@ -1,0 +1,587 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package embedshim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/fuweid/embedshim/pkg/exitsnoop"
+	"github.com/fuweid/embedshim/pkg/pidfd"
+	"github.com/fuweid/embedshim/pkg/runcext"
+
+	"github.com/cilium/ebpf"
+	"github.com/containerd/console"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/pkg/stdio"
+	"github.com/containerd/containerd/runtime"
+	"github.com/containerd/fifo"
+	runc "github.com/containerd/go-runc"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
+)
+
+type execProcess struct {
+	parent *initProcess
+
+	id           string
+	traceEventID uint64
+	spec         specs.Process
+	execState    execState
+
+	wg sync.WaitGroup
+
+	waitBlock chan struct{}
+
+	stdio   stdio.Stdio
+	console console.Console
+	io      *processIO
+	stdin   io.Closer
+	closers []io.Closer
+
+	mu     sync.Mutex
+	status int
+	exited time.Time
+	pid    safePid
+	pidFD  pidfd.FD
+}
+
+func (e *execProcess) ID() string {
+	return e.id
+}
+
+func (e *execProcess) Pid() int {
+	return e.pid.get()
+}
+
+func (e *execProcess) ExitStatus() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.status
+}
+
+func (e *execProcess) ExitedAt() time.Time {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.exited
+}
+
+func (e *execProcess) SetExited(status int) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.execState.SetExited(status)
+}
+
+func (e *execProcess) setExited(status int) {
+	e.status = unix.WaitStatus(status).ExitStatus()
+	e.exited = time.Now()
+
+	if e.parent.platform != nil {
+		e.parent.platform.ShutdownConsole(context.Background(), e.console)
+	}
+	close(e.waitBlock)
+}
+
+func (e *execProcess) CloseIO(ctx context.Context) error {
+	if stdin := e.Stdin(); stdin != nil {
+		if err := stdin.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *execProcess) Wait(ctx context.Context) (*runtime.Exit, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-e.waitBlock:
+		return &runtime.Exit{
+			Pid:       uint32(e.Pid()),
+			Status:    uint32(e.ExitStatus()),
+			Timestamp: e.ExitedAt(),
+		}, nil
+	}
+}
+
+func (e *execProcess) State(ctx context.Context) (runtime.State, error) {
+	st, err := e.Status(ctx)
+	if err != nil {
+		return runtime.State{}, err
+	}
+
+	status := runtime.Status(0) // Unknown
+	switch st {
+	case "created":
+		status = runtime.CreatedStatus
+	case "running":
+		status = runtime.RunningStatus
+	case "stopped":
+		status = runtime.StoppedStatus
+	}
+	return runtime.State{
+		Pid:        uint32(e.Pid()),
+		Status:     status,
+		Stdin:      e.stdio.Stdin,
+		Stdout:     e.stdio.Stdout,
+		Stderr:     e.stdio.Stderr,
+		Terminal:   e.stdio.Terminal,
+		ExitStatus: uint32(e.ExitStatus()),
+		ExitedAt:   e.ExitedAt(),
+	}, nil
+}
+
+func (e *execProcess) Delete(ctx context.Context) (*runtime.Exit, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if err := e.execState.Delete(ctx); err != nil {
+		return nil, err
+	}
+
+	e.shim().deleteExecProcess(e.id)
+	return &runtime.Exit{
+		Pid:       uint32(e.Pid()),
+		Status:    uint32(e.status),
+		Timestamp: e.exited,
+	}, nil
+}
+
+func (e *execProcess) delete(ctx context.Context) error {
+	waitTimeout(ctx, &e.wg, 2*time.Second)
+
+	if e.io != nil {
+		e.io.Close()
+	}
+	for _, c := range e.closers {
+		c.Close()
+	}
+
+	// silently ignore error
+	os.Remove(e.pidFilePath())
+	os.Remove(e.processJSONPath())
+	return nil
+}
+
+func (e *execProcess) ResizePty(_ context.Context, size runtime.ConsoleSize) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Resize(console.WinSize{
+		Width:  uint16(size.Width),
+		Height: uint16(size.Height),
+	})
+}
+
+func (e *execProcess) resize(ws console.WinSize) error {
+	if e.console == nil {
+		return nil
+	}
+
+	return e.console.Resize(ws)
+}
+
+func (e *execProcess) Kill(ctx context.Context, sig uint32, _ bool) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Kill(ctx, sig, false)
+}
+
+func (e *execProcess) kill(ctx context.Context, sig uint32, _ bool) error {
+	pid := e.pid.get()
+	switch {
+	case pid == 0:
+		return fmt.Errorf("process not created: %w", errdefs.ErrFailedPrecondition)
+	case !e.exited.IsZero():
+		return fmt.Errorf("process already finished: %w", errdefs.ErrNotFound)
+	default:
+		if err := e.pidFD.SendSignal(syscall.Signal(sig), 0); err != nil {
+			return fmt.Errorf("exec kill error: %w", checkKillError(err))
+		}
+	}
+	return nil
+}
+
+func (e *execProcess) Stdin() io.Closer {
+	return e.stdin
+}
+
+func (e *execProcess) Stdio() stdio.Stdio {
+	return e.stdio
+}
+
+func (e *execProcess) Start(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.execState.Start(ctx)
+}
+
+func (e *execProcess) start(ctx context.Context) (retErr error) {
+	// The reaper may receive exit signal right after
+	// the container is started, before the e.pid is updated.
+	// In that case, we want to block the signal handler to
+	// access e.pid until it is updated.
+	e.pid.Lock()
+	defer e.pid.Unlock()
+
+	var (
+		socket *runc.Socket
+		pio    *processIO
+
+		ioUID = int(e.parent.options.IoUid)
+		ioGID = int(e.parent.options.IoGid)
+
+		err error
+	)
+
+	if e.stdio.Terminal {
+		if socket, err = runc.NewTempConsoleSocket(); err != nil {
+			return fmt.Errorf("failed to create runc console socket: %w", err)
+		}
+		defer socket.Close()
+	} else {
+		// FIXME(fuweid):
+		//
+		// Maybe we should use pipe as relay for exec process, because
+		// it should be short-live process. And just in case that
+		// the buffer of fifo by UID will be filled with the log.
+		if pio, err = createIO(ctx, e.id, ioUID, ioGID, e.stdio); err != nil {
+			return fmt.Errorf("failed to create exec process I/O: %w", err)
+		}
+		e.io = pio
+	}
+
+	opts := &runc.ExecOpts{
+		PidFile: e.pidFilePath(),
+		Detach:  true,
+	}
+	if pio != nil {
+		opts.IO = pio.IO()
+	}
+	if socket != nil {
+		opts.ConsoleSocket = socket
+	}
+
+	invokeErr := e.invokeRuncExec(ctx, opts, func(syncPipe *os.File) (retErr error) {
+		var (
+			execPid uint32
+			pidFD   pidfd.FD
+			done    bool
+			err     error
+
+			pidMonitor    = e.pidMonitor()
+			execExitStore = pidMonitor.execStore
+		)
+
+		defer func() {
+			if retErr != nil {
+				if pidFD != 0 {
+					unix.Close(int(pidFD))
+				}
+
+				e.pid.pid = 0
+				e.pidFD = 0
+			}
+		}()
+
+		syncErr := runcext.ParseProcSync(syncPipe, func(msg *runcext.ProcSync) error {
+			switch msg.Type {
+			case runcext.ProcSyncExecPid:
+				if err = e.handleIOAfterExec(ctx, pio, socket); err != nil {
+					return err
+				}
+
+				err = func() (retErr error) {
+					pidMonitor.Lock()
+					defer pidMonitor.Unlock()
+
+					execPid = msg.Pid
+
+					nsInfo, err := getPidnsInfo(execPid)
+					if err != nil {
+						return err
+					}
+
+					pidFD, err = pidfd.Open(execPid, 0)
+					if err != nil {
+						return err
+					}
+
+					defer func() {
+						if retErr != nil {
+							unix.Close(int(pidFD))
+						}
+					}()
+
+					return execExitStore.Trace(execPid,
+						&exitsnoop.TaskInfo{
+							TraceID:   e.traceEventID,
+							PidnsInfo: nsInfo,
+						},
+					)
+				}()
+				if err != nil {
+					return err
+				}
+				return runcext.WriteProcSyncMessage(syncPipe, runcext.NewProcSyncExecPidDoneMessage())
+
+			case runcext.ProcSyncExecStatus:
+				err = func() error {
+					if !msg.Exited {
+						return nil
+					}
+
+					pidMonitor.Lock()
+					defer pidMonitor.Unlock()
+
+					taskInfo, err := execExitStore.GetTracingTask(execPid)
+					if err == nil && taskInfo.TraceID == e.traceEventID {
+						err = execExitStore.DeleteTracingTask(execPid)
+					}
+
+					if err != nil && !errors.Is(err, ebpf.ErrKeyNotExist) {
+						return err
+					}
+
+					return execExitStore.ExitedEventFromWaitStatus(e.traceEventID, execPid, msg.ExitedStatus)
+				}()
+				if err != nil {
+					return err
+				}
+
+				done = true
+
+				return runcext.WriteProcSyncMessage(syncPipe, runcext.NewProcSyncExecStatusDoneMessage())
+			default:
+				return fmt.Errorf("unexpected message: %+v", msg)
+			}
+		})
+		syncPipe.Close()
+
+		if syncErr != nil {
+			return syncErr
+		}
+		if !done {
+			return fmt.Errorf("unexpected to abort sync from child side")
+		}
+
+		e.pid.pid = int(execPid)
+		e.pidFD = pidFD
+		return pidMonitor.pidPoller.Add(pidFD, func() error {
+			execPid := e.Pid()
+
+			status := 255
+
+			event, err := execExitStore.GetExitedEvent(e.traceEventID)
+			if err == nil && event.Pid == uint32(execPid) {
+				status = int(event.ExitCode)
+			}
+			execExitStore.DeleteExitedEvent(e.traceEventID)
+
+			e.SetExited(status)
+			return nil
+		})
+	})
+	if invokeErr != nil {
+		close(e.waitBlock)
+		return e.parent.runtimeError(err, "OCI runtime exec failed")
+	}
+	return nil
+}
+
+func (e *execProcess) handleIOAfterExec(ctx context.Context, pio *processIO, socket *runc.Socket) error {
+	if e.stdio.Stdin != "" {
+		if err := e.openStdin(e.stdio.Stdin); err != nil {
+			return err
+		}
+	}
+
+	if socket != nil {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		console, err := socket.ReceiveMaster()
+		if err != nil {
+			return fmt.Errorf("failed to retrieve console master: %w", err)
+		}
+
+		if e.console, err = e.parent.platform.CopyConsole(ctx, console, e.id, e.stdio.Stdin, e.stdio.Stdout, e.stdio.Stderr, &e.wg); err != nil {
+			return fmt.Errorf("failed to start console copy: %w", err)
+		}
+	} else {
+		if err := pio.CopyStdin(); err != nil {
+			return fmt.Errorf("failed to start io pipe copy: %w", err)
+		}
+	}
+	return nil
+}
+
+func (e *execProcess) invokeRuncExec(ctx context.Context, opts *runc.ExecOpts, syncFn func(syncPipe *os.File) error) (retErr error) {
+	processJSON := e.processJSONPath()
+	stdioFDCnt := 3
+
+	specF, err := os.Create(processJSON)
+	if err != nil {
+		return fmt.Errorf("failed to create %s: %w", processJSON, err)
+	}
+	defer os.Remove(processJSON)
+
+	err = json.NewEncoder(specF).Encode(e.spec)
+	specF.Close()
+	if err != nil {
+		return fmt.Errorf("failed to encode process.json: %w", err)
+	}
+
+	parentSyncPipe, childSyncPipe, err := runcext.NewSocketPair("exec-" + e.id)
+	if err != nil {
+		return fmt.Errorf("failed to init sync pipe: %w", err)
+	}
+	defer func() {
+		parentSyncPipe.Close()
+		childSyncPipe.Close()
+	}()
+
+	args := []string{"exec", "--process", processJSON}
+	oargs, err := runcext.RuncExecOptsArgs(opts)
+	if err != nil {
+		return err
+	}
+	args = append(args, oargs...)
+
+	execCmd := runcext.RuntimeCommand(ctx, true, e.parent.runtime, append(args, e.parent.ID())...)
+
+	execCmd.ExtraFiles = append(execCmd.ExtraFiles, childSyncPipe)
+	execCmd.Env = append(execCmd.Env,
+		runcext.EnvNameProcSyncPipe+"="+strconv.Itoa(stdioFDCnt+len(execCmd.ExtraFiles)-1))
+
+	if opts.IO != nil {
+		opts.Set(execCmd)
+	}
+
+	if err := execCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start runc-exec ext: %w", err)
+	}
+	childSyncPipe.Close()
+
+	waited := false
+	defer func() {
+		if retErr != nil && !waited {
+			execCmd.Process.Kill()
+			execCmd.Wait()
+		}
+	}()
+
+	if opts.IO != nil {
+		if c, ok := opts.IO.(runc.StartCloser); ok {
+			if err := c.CloseAfterStart(); err != nil {
+				return fmt.Errorf("failed to close io after start: %w", err)
+			}
+		}
+	}
+
+	errCh := make(chan error, 1)
+
+	go func() (retErr error) {
+		defer func() {
+			if retErr != nil {
+				errCh <- retErr
+			}
+			close(errCh)
+		}()
+
+		return syncFn(parentSyncPipe)
+	}()
+
+	err = execCmd.Wait()
+	waited = true
+
+	if err1 := <-errCh; err == nil {
+		err = err1
+	}
+	return err
+}
+
+func (e *execProcess) Status(ctx context.Context) (string, error) {
+	s, err := e.parent.Status(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// if the container as a whole is in the pausing/paused state, so are all
+	// other processes inside the container, use container state here
+	switch s {
+	case "paused", "pausing":
+		return s, nil
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.execState.Status(ctx)
+}
+
+func (e *execProcess) pidFilePath() string {
+	return filepath.Join(e.parent.bundle.Path, fmt.Sprintf("%s.pid", e.id))
+}
+
+func (e *execProcess) processJSONPath() string {
+	return filepath.Join(e.parent.bundle.Path, fmt.Sprintf("%s.json", e.id))
+}
+
+func (e *execProcess) pidMonitor() *monitor {
+	return e.parent.parent.manager.monitor
+}
+
+func (e *execProcess) shim() *shim {
+	return e.parent.parent
+}
+
+func (e *execProcess) openStdin(path string) error {
+	sc, err := fifo.OpenFifo(context.Background(), path, syscall.O_WRONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open stdin fifo %s: %w", path, err)
+	}
+
+	e.stdin = sc
+	e.closers = append(e.closers, sc)
+	return nil
+}
+
+// safePid is a thread safe wrapper for pid.
+type safePid struct {
+	sync.Mutex
+	pid int
+}
+
+func (s *safePid) get() int {
+	s.Lock()
+	defer s.Unlock()
+	return s.pid
+}

--- a/exec_process_state.go
+++ b/exec_process_state.go
@@ -1,0 +1,171 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package embedshim
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/console"
+)
+
+type execState interface {
+	Resize(console.WinSize) error
+	Start(context.Context) error
+	Delete(context.Context) error
+	Kill(context.Context, uint32, bool) error
+	SetExited(int)
+	Status(context.Context) (string, error)
+}
+
+type execCreatedState struct {
+	p *execProcess
+}
+
+func (s *execCreatedState) transition(name string) error {
+	switch name {
+	case "running":
+		s.p.execState = &execRunningState{p: s.p}
+	case "stopped":
+		s.p.execState = &execStoppedState{p: s.p}
+	case "deleted":
+		s.p.execState = &deletedState{}
+	default:
+		return fmt.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execCreatedState) Resize(ws console.WinSize) error {
+	return s.p.resize(ws)
+}
+
+func (s *execCreatedState) Start(ctx context.Context) error {
+	if err := s.p.start(ctx); err != nil {
+		return err
+	}
+
+	return s.transition("running")
+}
+
+func (s *execCreatedState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+
+	return s.transition("deleted")
+}
+
+func (s *execCreatedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execCreatedState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *execCreatedState) Status(ctx context.Context) (string, error) {
+	return "created", nil
+}
+
+type execRunningState struct {
+	p *execProcess
+}
+
+func (s *execRunningState) transition(name string) error {
+	switch name {
+	case "stopped":
+		s.p.execState = &execStoppedState{p: s.p}
+	default:
+		return fmt.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execRunningState) Resize(ws console.WinSize) error {
+	return s.p.resize(ws)
+}
+
+func (s *execRunningState) Start(ctx context.Context) error {
+	return fmt.Errorf("cannot start a running process")
+}
+
+func (s *execRunningState) Delete(ctx context.Context) error {
+	return fmt.Errorf("cannot delete a running process")
+}
+
+func (s *execRunningState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execRunningState) SetExited(status int) {
+	s.p.setExited(status)
+
+	if err := s.transition("stopped"); err != nil {
+		panic(err)
+	}
+}
+
+func (s *execRunningState) Status(ctx context.Context) (string, error) {
+	return "running", nil
+}
+
+type execStoppedState struct {
+	p *execProcess
+}
+
+func (s *execStoppedState) transition(name string) error {
+	switch name {
+	case "deleted":
+		s.p.execState = &deletedState{}
+	default:
+		return fmt.Errorf("invalid state transition %q to %q", stateName(s), name)
+	}
+	return nil
+}
+
+func (s *execStoppedState) Resize(ws console.WinSize) error {
+	return fmt.Errorf("cannot resize a stopped container")
+}
+
+func (s *execStoppedState) Start(ctx context.Context) error {
+	return fmt.Errorf("cannot start a stopped process")
+}
+
+func (s *execStoppedState) Delete(ctx context.Context) error {
+	if err := s.p.delete(ctx); err != nil {
+		return err
+	}
+
+	return s.transition("deleted")
+}
+
+func (s *execStoppedState) Kill(ctx context.Context, sig uint32, all bool) error {
+	return s.p.kill(ctx, sig, all)
+}
+
+func (s *execStoppedState) SetExited(status int) {
+	// no op
+}
+
+func (s *execStoppedState) Status(ctx context.Context) (string, error) {
+	return "stopped", nil
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
+	github.com/urfave/cli v1.22.2
 	go.etcd.io/bbolt v1.3.5
 	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f
 )

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	go.etcd.io/bbolt v1.3.5
-	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8
+	golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f
 )

--- a/go.sum
+++ b/go.sum
@@ -806,8 +806,8 @@ golang.org/x/sys v0.0.0-20201202213521-69691e467435/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
-golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f h1:rlezHXNlxYWvBCzNses9Dlc7nGFaNMJeqLolcmQSSZY=
+golang.org/x/sys v0.0.0-20220330033206-e17cdc41300f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/exitsnoop/load_test.go
+++ b/pkg/exitsnoop/load_test.go
@@ -1,0 +1,67 @@
+package exitsnoop
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+)
+
+func TestStoreBasic(t *testing.T) {
+	store, err := NewStoreFromAttach()
+	if err != nil {
+		t.Fatalf("failed to new store from attach: %v", err)
+	}
+	defer store.Close()
+
+	cmd := exec.Command("sleep", "1d")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start sleep command: %v", err)
+	}
+
+	pid := uint32(cmd.Process.Pid)
+
+	nsInfo, err := getPidnsInfo(pid)
+	if err != nil {
+		t.Fatalf("failed to get pidns info: %v", err)
+	}
+
+	traceID := uint64(1)
+
+	if err := store.Trace(pid, &TaskInfo{
+		TraceID:   traceID,
+		PidnsInfo: nsInfo,
+	}); err != nil {
+		t.Fatalf("failed to trace: %v", err)
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("failed to kill sleep: %v", err)
+	}
+
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("expected error(killed) but got nil")
+	}
+
+	event, err := store.GetExitedEvent(traceID)
+	if err != nil {
+		t.Fatalf("expected no error, but got: %v", err)
+	}
+	if event.Pid != pid {
+		t.Fatalf("expected %v, but got %v", pid, event.Pid)
+	}
+}
+
+func getPidnsInfo(pid uint32) (PidnsInfo, error) {
+	f, err := os.Stat(filepath.Join("/proc", strconv.Itoa(int(pid)), "ns", "pid"))
+	if err != nil {
+		return PidnsInfo{}, err
+	}
+
+	return PidnsInfo{
+		Dev: (f.Sys().(*syscall.Stat_t)).Dev,
+		Ino: (f.Sys().(*syscall.Stat_t)).Ino,
+	}, nil
+}

--- a/pkg/exitsnoop/map.go
+++ b/pkg/exitsnoop/map.go
@@ -70,6 +70,15 @@ func (store *Store) DeleteTracingTask(pid uint32) error {
 	return store.tracingTasks.Delete(pid)
 }
 
+func (store *Store) ExitedEventFromWaitStatus(traceEventID uint64, pid uint32, status uint32) error {
+	info := ExitStatus{
+		Pid:      pid,
+		ExitCode: int32(status),
+	}
+
+	return store.exitedEvents.Update(traceEventID, &info, ebpf.UpdateNoExist)
+}
+
 func (store *Store) GetExitedEvent(traceEventID uint64) (*ExitStatus, error) {
 	info := &ExitStatus{}
 

--- a/pkg/pidfd/syscall.go
+++ b/pkg/pidfd/syscall.go
@@ -73,3 +73,12 @@ func (fd FD) Waitid(info *Siginfo, options int, rusage *Rusage) error {
 	}
 	return nil
 }
+
+// GetFd obtain a duplicate of another process's file descriptor.
+func (fd FD) GetFd(targetFD int, flags int) (int, error) {
+	// From https://man7.org/linux/man-pages/man2/pidfd_getfd.2.html
+	//
+	// The flags argument is reserved for future use.  Currently, it
+	// must be specified as 0.
+	return unix.PidfdGetfd(int(fd), targetFD, flags)
+}

--- a/pkg/pidfd/syscall.go
+++ b/pkg/pidfd/syscall.go
@@ -1,8 +1,35 @@
 package pidfd
 
 import (
+	"unsafe"
+
 	"golang.org/x/sys/unix"
 )
+
+// PPIDFD is the first argument to waitid for pidfd.
+const PPIDFD int = 3
+
+// Siginfo extends the unix.Siginfo with Pid, which used to check the process
+// state.
+//
+// From https://man7.org/linux/man-pages/man2/waitid.2.html:
+//
+// If WNOHANG was specified in options and there were no children in a waitable
+// state, then waitid() returns 0 immediately and the state of the siginfo_t
+// structure pointed to by infop depends on the implementation. To (portably)
+// distinguish this case from that where a child was in a waitable state, zero
+// out the si_pid field before the call and check for a nonzero value in this
+// field after the call returns.
+type Siginfo struct {
+	Signo int32
+	Errno int32
+	Code  int32
+	_     int32
+	Pid   uint32
+	_     [108]byte
+}
+
+type Rusage = unix.Rusage
 
 type FD int
 
@@ -31,4 +58,18 @@ func (fd FD) SendSignal(signal unix.Signal, flags int) error {
 	// values that are implicitly supplied when a signal is sent using
 	// kill(2).
 	return unix.PidfdSendSignal(int(fd), signal, nil, flags)
+}
+
+// Waitid provides more precise control over which child state changes to wait for.
+func (fd FD) Waitid(info *Siginfo, options int, rusage *Rusage) error {
+	_, _, e1 := unix.Syscall6(unix.SYS_WAITID,
+		uintptr(PPIDFD),
+		uintptr(fd),
+		uintptr(unsafe.Pointer(info)),
+		uintptr(options),
+		uintptr(unsafe.Pointer(rusage)), 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
 }

--- a/pkg/runcext/sync.go
+++ b/pkg/runcext/sync.go
@@ -1,0 +1,140 @@
+package runcext
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+var EnvNameProcSyncPipe = "_RUNCEXT_PROC_SYNC_PIPE"
+
+// ProcSyncType is used for synchronisation between parent and child process
+// during setup containers exec processes.
+//
+// Since the exec process doesn't like container init which has two-steps
+// to setup, we need a wrapper runc-exec commandline to setup pidfd exit event
+// monitor like what we does for runc-init.
+//
+// NOTE: The design is based on runc's syncType from commit[1].
+//
+// [1] https://github.com/opencontainers/runc/blob/899342b5d49434611635d64f64c343e2a1aeee0a/libcontainer/sync.go
+type ProcSyncType string
+
+const (
+	ProcSyncError ProcSyncType = "error"
+
+	// [ runc-exec-ext(child)]		     [     parent     ]
+	//
+	// 	SyncExecPid		-->	           read pid
+	//
+	//				<--             SyncExecPidDone
+	//
+	//    SyncExecPidStatus		-->	      exec current status
+	//
+	//				<--	       SyncExecPidStatusDone
+	//
+	// NOTE:
+	//
+	// The commit[1] only supports pidfd type on waitid, not including
+	// the non-parent support. We need one extra step to check exec process
+	// is still alive. In the future, pidfd_wait[2] API can support waitid
+	// by non-parent process.
+	//
+	// [1] https://github.com/torvalds/linux/commit/3695eae5fee0605f316fbaad0b9e3de791d7dfaf
+	// [2] https://lwn.net/Articles/794707/
+	ProcSyncExecPid        ProcSyncType = "execPid"
+	ProcSyncExecPidDone    ProcSyncType = "execPidDone"
+	ProcSyncExecStatus     ProcSyncType = "execStatus"
+	ProcSyncExecStatusDone ProcSyncType = "execStatusDone"
+)
+
+type ProcSync struct {
+	Type         ProcSyncType `json:"type"`
+	Pid          uint32       `json:"pid"`
+	Exited       bool         `json:"exited"`
+	ExitedStatus uint32       `json:"exited_status"`
+	Message      string       `json:"message,omitempty"`
+}
+
+func NewProcSyncExecPidMessage(pid uint32) ProcSync {
+	return ProcSync{
+		Type: ProcSyncExecPid,
+		Pid:  pid,
+	}
+}
+
+func NewProcSyncExecPidDoneMessage() ProcSync {
+	return ProcSync{
+		Type: ProcSyncExecPidDone,
+	}
+}
+
+func NewProcSyncExecStatusMessage(exited bool, status uint32) ProcSync {
+	return ProcSync{
+		Type:         ProcSyncExecStatus,
+		Exited:       exited,
+		ExitedStatus: status,
+	}
+}
+
+func NewProcSyncExecStatusDoneMessage() ProcSync {
+	return ProcSync{
+		Type: ProcSyncExecStatusDone,
+	}
+}
+
+func NewProcSyncErrorMessage(err error) ProcSync {
+	return ProcSync{
+		Type:    ProcSyncError,
+		Message: fmt.Errorf("error: %v", err).Error(),
+	}
+}
+
+func WriteProcSyncMessage(w io.Writer, msg ProcSync) error {
+	return writeJSON(w, msg)
+}
+
+func ReadProcSync(r io.Reader, expected ProcSyncType) error {
+	var msg ProcSync
+
+	if err := json.NewDecoder(r).Decode(&msg); err != nil {
+		return fmt.Errorf("failed reading error during sync: %w", err)
+	}
+
+	if msg.Type != expected {
+		return fmt.Errorf("expected type %v, but got %+v", expected, msg)
+	}
+	return nil
+}
+
+func ParseProcSync(pipe io.Reader, fn func(*ProcSync) error) error {
+	dec := json.NewDecoder(pipe)
+	for {
+		var msg ProcSync
+		if err := dec.Decode(&msg); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return err
+		}
+
+		if msg.Type == ProcSyncError {
+			return fmt.Errorf("unexpected error: %v", msg.Message)
+		}
+
+		if err := fn(&msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeJSON(w io.Writer, v interface{}) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}

--- a/pkg/runcext/utils.go
+++ b/pkg/runcext/utils.go
@@ -1,0 +1,102 @@
+package runcext
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/containerd/go-runc"
+	"golang.org/x/sys/unix"
+)
+
+func NewSocketPair(name string) (*os.File, *os.File, error) {
+	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return os.NewFile(uintptr(fds[1]), name+"-parent"), os.NewFile(uintptr(fds[0]), name+"-child"), nil
+}
+
+// PidFile is used to read pid from file named by --pid-file option.
+type PidFile struct {
+	path string
+}
+
+func NewPidFile(p string) *PidFile {
+	return &PidFile{
+		path: p,
+	}
+}
+
+func (p *PidFile) Path() string {
+	return p.path
+}
+
+func (p *PidFile) Read() (int, error) {
+	return runc.ReadPidFile(p.path)
+}
+
+// RuntimeCommand is based on github.com/containerd/go-runc@v1.0.0/command_linux.go
+func RuntimeCommand(ctx context.Context, r *runc.Runc, args ...string) *exec.Cmd {
+	command := r.Command
+	if command == "" {
+		command = runc.DefaultCommand
+	}
+
+	cmd := exec.CommandContext(ctx, command, append(runtimeArgs(r), args...)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: r.Setpgid,
+	}
+
+	// NOTIFY_SOCKET introduces a special behavior in runc but should only be set if invoked from systemd
+	cmd.Env = filterEnv(os.Environ(), "NOTIFY_SOCKET")
+	if r.PdeathSignal != 0 {
+		cmd.SysProcAttr.Pdeathsig = r.PdeathSignal
+	}
+	return cmd
+}
+
+func runtimeArgs(r *runc.Runc) (out []string) {
+	if r.Root != "" {
+		out = append(out, "--root", r.Root)
+	}
+	if r.Debug {
+		out = append(out, "--debug")
+	}
+	if r.Log != "" {
+		out = append(out, "--log", r.Log)
+	}
+	if r.LogFormat != "" {
+		out = append(out, "--log-format", string(r.LogFormat))
+	}
+	if r.Criu != "" {
+		out = append(out, "--criu", r.Criu)
+	}
+	if r.SystemdCgroup {
+		out = append(out, "--systemd-cgroup")
+	}
+	if r.Rootless != nil {
+		// nil stands for "auto" (differs from explicit "false")
+		out = append(out, "--rootless="+strconv.FormatBool(*r.Rootless))
+	}
+	return out
+}
+
+// filterEnv is copied from github.com/containerd/go-runc@v1.0.0/command_linux.go
+func filterEnv(in []string, names ...string) []string {
+	out := make([]string, 0, len(in))
+loop0:
+	for _, v := range in {
+		for _, k := range names {
+			if strings.HasPrefix(v, k+"=") {
+				continue loop0
+			}
+		}
+		out = append(out, v)
+	}
+	return out
+}

--- a/plugin.go
+++ b/plugin.go
@@ -197,7 +197,7 @@ func (manager *TaskManager) repollingInitProcess(init *initProcess) error {
 }
 
 func (manager *TaskManager) cleanInitProcessTraceEvent(init *initProcess) error {
-	return manager.monitor.store.DeleteExitedEvent(init.traceEventID)
+	return manager.monitor.initStore.DeleteExitedEvent(init.traceEventID)
 }
 
 func initOptionsFromCreateOpts(createOpts runtime.CreateOpts) (*options.Options, error) {
@@ -218,4 +218,14 @@ func initOptionsFromCreateOpts(createOpts runtime.CreateOpts) (*options.Options,
 		}
 	}
 	return initOpts, nil
+}
+
+type ctxTraceIDKey struct{}
+
+func withTraceID(ctx context.Context, traceID uint64) context.Context {
+	return context.WithValue(ctx, ctxTraceIDKey{}, traceID)
+}
+
+func traceIDFromContext(ctx context.Context) uint64 {
+	return ctx.Value(ctxTraceIDKey{}).(uint64)
 }


### PR DESCRIPTION

    [PATCH 7] init exec_process support
    
    Unlike runc-init, the exec process needs a runc-exec wrapper to be
    subreaper so that the embedshim can use pidfd to watch the process's
    exit event correctly.
    
    Since there is no way to recover the exec process after containerd
    restarted, this commit introduces new in-memory exitsnoop store to trace
    the exec process, just in case that there is no leaky items in map.
    
    And it is based release/1.5's exec_process code base. I make it to be
    implementation of runtime.Process. Basically, we don't need to use shim
    to wrap exec_process like init_process. I think in the future,
    init_process will be up to the shim layer.
    
    And one more thing, it is alpha version of exec :).
    
    [PATCH 6] .github: align goversion with matrix
    
    According to golangci-lint doc[1], the new version of golangci-lint
    action will use actions/setup-go@v2 result. Otherwise, it will use
    latest version of golang[2].
    
    REF:
    
    [1] https://github.com/golangci/golangci-lint-action
    [2] https://github.com/golangci/golangci-lint-action/issues/435
    
    [PATCH 5] cmd: add a runc-exec wrapper helper commandline
    
    [PATCH 4] pkg/runcext: introduce process sync proto
    
    [PATCH 3] pkg/pidfd: support pidfd_getfd
   
    [PATCH 2] .github: update go to 1.17.x

    [PATCH 1] pkg/pidfd: support waitid API
    
    [PATCH 0] pkg/es: support store from non-pinned maps
    
    Since the runC doesn't support check the exec-process's state in
    current, if we trace the exec-process in the same BPF map with
    container, the recover will be more complicated. And the runC-exec
    doesn't support fork-execve two steps pattern like init, it is also hard
    to recover it after restart containerd.
    
    So, we need other exitsnoop.Store to trace the exec process's exit event.
    The exitsnoop will be gone if containerd exits.
