### PR TITLE
fix: exitCode needs to be translated before use

### DIFF
--- a/init_process.go
+++ b/init_process.go
@@ -287,7 +287,7 @@ func (p *initProcess) SetExited(status int) {
 
 func (p *initProcess) setExited(status int) {
 	p.exited = time.Now()
-	p.status = status
+	p.status = unix.WaitStatus(status).ExitStatus()
 	if p.platform != nil {
 		p.platform.ShutdownConsole(context.Background(), p.console)
 


### PR DESCRIPTION
Current:

```
➜  embedshim git:(unstable) sudo ctr run --rm --runtime io.containerd.runtime.v1.embed docker.io/library/alpine:latest testing sh -c "exit 10"
➜  embedshim git:(unstable) echo $?
0
```

After:

```
➜  embedshim git:(fix-issue) sudo ctr run --rm --runtime io.containerd.runtime.v1.embed docker.io/library/alpine:latest testing sh -c "exit 10"
➜  embedshim git:(fix-issue) echo $?
10
```

Signed-off-by: Wei Fu <fuweid89@gmail.com>