### PR TITLE
pkg/exitsnoop: hold raw_tp link to prevent from GC

### DIFF
--- a/pkg/exitsnoop/load.go
+++ b/pkg/exitsnoop/load.go
@@ -37,10 +37,6 @@ var (
 // NewStoreFromAttach only opens but not pinned in bpffs, which has common
 // functionality with EnsureRunning. I think we should use options to merge
 // two function in the future.
-//
-// FIXME(fuweid):
-//
-// How to close the link after close the store?
 func NewStoreFromAttach() (_ *Store, retErr error) {
 	spec, err := ebpf.LoadCollectionSpecFromReader(bytes.NewReader(progByteCode))
 	if err != nil {
@@ -63,7 +59,7 @@ func NewStoreFromAttach() (_ *Store, retErr error) {
 		}
 	}()
 
-	_, err = link.AttachRawTracepoint(link.RawTracepointOptions{
+	link, err := link.AttachRawTracepoint(link.RawTracepointOptions{
 		Name:    "sched_process_exit",
 		Program: collection.Programs[bpfProgName],
 	})
@@ -74,6 +70,7 @@ func NewStoreFromAttach() (_ *Store, retErr error) {
 	return &Store{
 		tracingTasks: collection.Maps[bpfMapTracingTasks],
 		exitedEvents: collection.Maps[bpfMapExitedEvents],
+		link:         link,
 	}, nil
 }
 


### PR DESCRIPTION
The cilium/ebpf defines sys.FD's SetFinalizer to close fd when GC.
Since the exec process's exit code needs memory-type exitsnoop, we
should keep the reference on the raw_tp link. Otherwise, the exitsnoop
will be gone and process's exit code will be wrong.

Signed-off-by: Wei Fu <fuweid89@gmail.com>