### PR TITLE
fix: cgroup leak when delete container from pod

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/events/exchange"
 	"github.com/containerd/containerd/identifiers"
+	"github.com/containerd/containerd/log"
 	"github.com/containerd/containerd/metadata"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
@@ -154,7 +155,27 @@ func (manager *TaskManager) Add(ctx context.Context, task runtime.Task) error {
 }
 
 func (manager *TaskManager) Delete(ctx context.Context, id string) {
-	manager.tasks.Delete(ctx, id)
+	var err error
+	defer func() {
+		if err != nil {
+			log.G(ctx).WithError(err).Errorf("failed to delete task %s", id)
+		}
+	}()
+
+	ns, err := namespaces.NamespaceRequired(ctx)
+	if err != nil {
+		return
+	}
+	bundle, err := pkgbundle.LoadBundle(manager.stateDir, ns, id)
+	if err != nil {
+		return
+	}
+	shim, err := manager.loadShim(ctx, bundle)
+	if err != nil {
+		return
+	}
+
+	shim.Delete(ctx)
 }
 
 func (manager *TaskManager) Tasks(ctx context.Context, all bool) ([]runtime.Task, error) {

--- a/shim.go
+++ b/shim.go
@@ -304,7 +304,7 @@ func (s *shim) Delete(ctx context.Context) (*runtime.Exit, error) {
 	}
 
 	s.manager.cleanInitProcessTraceEvent(s.init)
-	s.manager.Delete(ctx, s.init.ID())
+	s.manager.tasks.Delete(ctx, s.init.ID())
 
 	return &runtime.Exit{
 		Pid:       uint32(s.init.pid),


### PR DESCRIPTION
There are some situations that containerd(CRI) will be asked to delete containers from a pod which not terminated, for example,  kubelet will clean initContainers before start pod(`pruneInitContainersBeforeStart`).

Currently, `TaskManager`'s `Delete` function only removes the task item from map, the container's resources like bundle and cgroup will leak on the host, this commit fixes this.