### PR TITLE
update kernel version dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ works in progress, do not use in production.
 * raw tracepoint bpf >= kernel v4.18
 * CO-RE BTF vmlinux support >= kernel v5.4
 * pidfd polling >= kernel v5.3
+* bpf links >= kernel v5.7
 
 ## License
 


### PR DESCRIPTION
The eBPF function persistence depends on `BPF_LINK_CREATE`, which was provided beginning with kernel version 5.7